### PR TITLE
You can now set LED color order for 3 and 4 color strips

### DIFF
--- a/python/examples/multistrandtest.py
+++ b/python/examples/multistrandtest.py
@@ -15,7 +15,7 @@ LED_1_DMA        = 5       # DMA channel to use for generating signal (Between 1
 LED_1_BRIGHTNESS = 128     # Set to 0 for darkest and 255 for brightest
 LED_1_INVERT     = False   # True to invert the signal (when using NPN transistor level shift)
 LED_1_CHANNEL    = 0       # 0 or 1
-LED_1_STRIP      = ws.SK6812_STRIP_RGBW	
+LED_1_STRIP      = ws.SK6812_STRIP_GRBW	
 
 LED_2_COUNT      = 15      # Number of LED pixels.
 LED_2_PIN        = 13      # GPIO pin connected to the pixels (must support PWM! GPIO 13 or 18 on RPi 3).
@@ -24,7 +24,7 @@ LED_2_DMA        = 10      # DMA channel to use for generating signal (Between 1
 LED_2_BRIGHTNESS = 128     # Set to 0 for darkest and 255 for brightest
 LED_2_INVERT     = False   # True to invert the signal (when using NPN transistor level shift)
 LED_2_CHANNEL    = 1       # 0 or 1
-LED_2_STRIP      = ws.WS2811_STRIP_RGB	
+LED_2_STRIP      = ws.WS2811_STRIP_GRB	
 
 def multiColorWipe(color1, color2, wait_ms=5):
 	global strip1

--- a/python/examples/multistrandtest.py
+++ b/python/examples/multistrandtest.py
@@ -8,7 +8,7 @@ import time
 from neopixel import *
 
 # LED strip configuration:
-LED_1_COUNT      = 60      # Number of LED pixels.
+LED_1_COUNT      = 30      # Number of LED pixels.
 LED_1_PIN        = 18      # GPIO pin connected to the pixels (must support PWM! GPIO 13 and 18 on RPi 3).
 LED_1_FREQ_HZ    = 800000  # LED signal frequency in hertz (usually 800khz)
 LED_1_DMA        = 5       # DMA channel to use for generating signal (Between 1 and 14)
@@ -17,10 +17,10 @@ LED_1_INVERT     = False   # True to invert the signal (when using NPN transisto
 LED_1_CHANNEL    = 0       # 0 or 1
 LED_1_STRIP      = ws.SK6812_STRIP_RGBW	
 
-LED_2_COUNT      = 30      # Number of LED pixels.
+LED_2_COUNT      = 15      # Number of LED pixels.
 LED_2_PIN        = 13      # GPIO pin connected to the pixels (must support PWM! GPIO 13 or 18 on RPi 3).
 LED_2_FREQ_HZ    = 800000  # LED signal frequency in hertz (usually 800khz)
-LED_2_DMA        = 10       # DMA channel to use for generating signal (Between 1 and 14)
+LED_2_DMA        = 10      # DMA channel to use for generating signal (Between 1 and 14)
 LED_2_BRIGHTNESS = 128     # Set to 0 for darkest and 255 for brightest
 LED_2_INVERT     = False   # True to invert the signal (when using NPN transistor level shift)
 LED_2_CHANNEL    = 1       # 0 or 1

--- a/ws2811.c
+++ b/ws2811.c
@@ -664,8 +664,6 @@ int ws2811_render(ws2811_t *ws2811)
                     // 4 color LED - R, G, B + W
                     array_size = 4;
                     break;
-                // default:
-                    // exit (-1);
             }
 
             // if (channel->strip_type == SK6812_STRIP_RGBW) {

--- a/ws2811.c
+++ b/ws2811.c
@@ -665,7 +665,7 @@ int ws2811_render(ws2811_t *ws2811)
                     array_size = 4;
                     break;
                 default:
-                    exit (-1);
+                    // exit (-1);
             }
 
             // if (channel->strip_type == SK6812_STRIP_RGBW) {

--- a/ws2811.c
+++ b/ws2811.c
@@ -647,14 +647,22 @@ int ws2811_render(ws2811_t *ws2811)
 
 
 //if (i<10) printf ("i %3d red %02x green %02x blue %02x white %02x\n", i, color[0], color[1], color[2], color[3]);
-            int array_size = 3; // assume 3 for RGB
 
             // Forgive me for this monstrosity. I'm sure there must be a better way.
             // This test should be based on LED_COLOURS, but that should be set
             // dynamically, instead of this ever expanding list... 
-            char rgbw_leds[]="SK6812_STRIP_RGBW,SK6812_STRIP_RBGW,SK6812_STRIP_GRBW,SK6812_STRIP_GBRW,SK6812_STRIP_BRGW,SK6812_STRIP_BGRW";
-            if ( strstr(rgbw_leds, channel->strip_type) != NULL ) {
-                array_size = 4; // this strip needs 4 - RGB + W
+            switch (channel->strip_type) {
+                case SK6812_STRIP_RGBW:
+                case SK6812_STRIP_RBGW:
+                case SK6812_STRIP_GRBW:
+                case SK6812_STRIP_GBRW:
+                case SK6812_STRIP_BRGW:
+                case SK6812_STRIP_BGRW:
+                    int array_size = 4; // 4 color LED - R, G, B + W
+                    break;
+                default:
+                    int array_size = 3; // 3 color LED - R, G, B
+                    exit (-1);
             }
 
             // if (channel->strip_type == SK6812_STRIP_RGBW) {

--- a/ws2811.c
+++ b/ws2811.c
@@ -53,8 +53,8 @@
 
 #define OSC_FREQ                                 19200000   // crystal frequency
 
-/* 3 colors, 8 bits per byte, 3 symbols per bit + 55uS low for reset signal */
-#define LED_COLOURS				4
+/* 4 colors (R, G, B + W), 8 bits per byte, 3 symbols per bit + 55uS low for reset signal */
+#define LED_COLOURS                              4
 #define LED_RESET_uS                             55
 #define LED_BIT_COUNT(leds, freq)                ((leds * LED_COLOURS * 8 * 3) + ((LED_RESET_uS * \
                                                   (freq * 3)) / 1000000))
@@ -647,12 +647,21 @@ int ws2811_render(ws2811_t *ws2811)
 
 
 //if (i<10) printf ("i %3d red %02x green %02x blue %02x white %02x\n", i, color[0], color[1], color[2], color[3]);
-            int array_size = 4;	// assume 3 for RGB
-            if (channel->strip_type == SK6812_STRIP_RGBW) {
-		array_size = 4;	// this strip needs 4 - RGB + W
+            int array_size = 3; // assume 3 for RGB
+
+            // Forgive me for this monstrosity. I'm sure there must be a better way.
+            // This test should be based on LED_COLOURS, but that should be set
+            // dynamically, instead of this ever expanding list... 
+            char rgbw_leds[]="SK6812_STRIP_RGBW,SK6812_STRIP_RBGW,SK6812_STRIP_GRBW,SK6812_STRIP_GBRW,SK6812_STRIP_BRGW,SK6812_STRIP_BGRW";
+            if ( strstr(rgbw_leds, channel->strip_type) != NULL ) {
+                array_size = 4; // this strip needs 4 - RGB + W
             }
 
-            for (j = 0; j < array_size; j++)        // Color
+            // if (channel->strip_type == SK6812_STRIP_RGBW) {
+            //     array_size = 4; // this strip needs 4 - RGB + W
+            // }
+
+            for (j = 0; j < array_size; j++)               // Color
             {
                 for (k = 7; k >= 0; k--)                   // Bit
                 {

--- a/ws2811.c
+++ b/ws2811.c
@@ -664,7 +664,7 @@ int ws2811_render(ws2811_t *ws2811)
                     // 4 color LED - R, G, B + W
                     array_size = 4;
                     break;
-                default:
+                // default:
                     // exit (-1);
             }
 

--- a/ws2811.c
+++ b/ws2811.c
@@ -648,6 +648,9 @@ int ws2811_render(ws2811_t *ws2811)
 
 //if (i<10) printf ("i %3d red %02x green %02x blue %02x white %02x\n", i, color[0], color[1], color[2], color[3]);
 
+            // Assume 3 color LED - R, G, B
+            int array_size = 3;
+
             // Forgive me for this monstrosity. I'm sure there must be a better way.
             // This test should be based on LED_COLOURS, but that should be set
             // dynamically, instead of this ever expanding list... 
@@ -658,10 +661,10 @@ int ws2811_render(ws2811_t *ws2811)
                 case SK6812_STRIP_GBRW:
                 case SK6812_STRIP_BRGW:
                 case SK6812_STRIP_BGRW:
-                    int array_size = 4; // 4 color LED - R, G, B + W
+                    // 4 color LED - R, G, B + W
+                    array_size = 4;
                     break;
                 default:
-                    int array_size = 3; // 3 color LED - R, G, B
                     exit (-1);
             }
 

--- a/ws2811.c
+++ b/ws2811.c
@@ -647,7 +647,7 @@ int ws2811_render(ws2811_t *ws2811)
 
 
 //if (i<10) printf ("i %3d red %02x green %02x blue %02x white %02x\n", i, color[0], color[1], color[2], color[3]);
-            int array_size = 3;	// assume 3 for RGB
+            int array_size = 4;	// assume 3 for RGB
             if (channel->strip_type == SK6812_STRIP_RGBW) {
 		array_size = 4;	// this strip needs 4 - RGB + W
             }


### PR DESCRIPTION
My SK6812 and WS2812b strips expect color info in G,R,B,W and G,R,B order, but the world (and the neopixel Color() method) works in RGB. Now you can specify the color order for 4 color LEDs like you could for 3 color previously, even in a multi strand setup.

Set your `strip_type` to one of the following to make it match the order your strip wants the colors provided in:

SK6812_STRIP_RGBW
SK6812_STRIP_RBGW
SK6812_STRIP_GRBW
SK6812_STRIP_GBRW
SK6812_STRIP_BRGW
SK6812_STRIP_BGRW
WS2811_STRIP_RGB
WS2811_STRIP_RBG
WS2811_STRIP_GRB
WS2811_STRIP_GBR
WS2811_STRIP_BRG
WS2811_STRIP_BGR

  The switch statement in ws2811.c is a little hokey, but I'm no C guru. If there's a better way, let me know.
